### PR TITLE
[Quill Icons] Prevents slack notification if there exist an open "quill icons" PR.

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -18,7 +18,16 @@ jobs:
           else
             echo "SLACK_MESSAGE=❌ Quill Icons Park could not be updated.\nPlease see the details at https://github.com/deriv-com/quill-icons-park/actions" >> "$GITHUB_OUTPUT"
           fi
+
+      - name: Check for blocking PRs in Quill Icons Park
+        id: open_pull_requests
+        run: |
+          api_endpoint="https://api.github.com/repos/${{github.repository}}/pulls?state=open"
+          open_pull_requests=$(curl -sSL -H "Accept: application/vnd.github.v3+json" "$api_endpoint")
+          echo "blocking_pull_requests=$(echo "$open_pull_requests" | jq 'map(select(.title == "[Quill-Icons] 🗂️ New version available!")) | length')" >> "$GITHUB_OUTPUT"
+
       - name: Send Slack Notification
+        if: steps.open_pull_requests.outputs.blocking_pull_requests == 0
         shell: bash
         run: |
           curl \


### PR DESCRIPTION
- Slack notifications will only be sent if there are no open PRs with the title "[Quill-Icons] 🗂️ New version available!".
- This ensures that only 1 notification will be sent to slack, only at the time of merging the PR.